### PR TITLE
Correctly show the color for charging.

### DIFF
--- a/pyStatus/plugins/Battery.py
+++ b/pyStatus/plugins/Battery.py
@@ -59,4 +59,5 @@ class Battery(BarItem):
     @staticmethod
     def getValueFromLocation(path):
         with open(path) as foo:
-            return ''.join(foo.readlines())
+            return ''.join(foo.readlines()).strip()
+


### PR DESCRIPTION
The color for charging was not displayed properly because a newline at the end.
